### PR TITLE
Use message exchange to synchronize two subprocesses.

### DIFF
--- a/gpu-sched-exp/gpu-tester/src/run_model.py
+++ b/gpu-sched-exp/gpu-tester/src/run_model.py
@@ -2,6 +2,7 @@ import argparse
 import csv
 import json
 import os
+import select
 import signal
 import sys
 from time import perf_counter_ns, sleep
@@ -20,9 +21,12 @@ def signal_handler(sig, frame):
     global RUNNING
     RUNNING = False
 
+def debug_print(msg):
+    print(msg, file=sys.stderr, flush=True)
+
 
 class SchedulerTester():
-    def __init__(self, control, config, device_id) -> None:
+    def __init__(self, control, config, device_id, sync_model_load) -> None:
         self.config = config
         self.device_id = device_id
         self.control = control
@@ -55,6 +59,16 @@ class SchedulerTester():
             ['start_timestamp_ns', 'end_timestamp_ns', 'jct_ms',
              'max_allocated_gpu_memory_allocated_byte',
              'max_reserved_gpu_memory_byte'])
+        debug_print("model loaded")
+        if sync_model_load:
+            print("model loaded", file=sys.stdout, flush=True)
+            poll_result = select.select([sys.stdin], [], [], 120)[0]
+            if poll_result:
+                msg = sys.stdin.readline().rstrip()
+                debug_print(msg)
+            else:
+                # continue to run anyway
+                return
 
     def __del__(self):
         self.csv_fh.flush()
@@ -68,9 +82,10 @@ class SchedulerTester():
                 assert suffix is not None
                 self.lib.setMem(1, suffix.encode())
             except Exception as e:
-                print(e)
+                debug_print(e)
         # torch.cuda.synchronize()  # make sure there is no time sharing between large job and small job
         start_t: int = perf_counter_ns()
+        assert self.model is not None
         res = self.model()
         torch.cuda.synchronize()
         end_t: int = perf_counter_ns()
@@ -80,9 +95,7 @@ class SchedulerTester():
                 assert suffix is not None
                 self.lib.setMem(0, suffix.encode())
             except Exception as e:
-                print(e)
-            # read and print shared memory's current value
-            # lib.printCurr()
+                debug_print(e)
         max_alloc_mem_byte = torch.cuda.max_memory_allocated(self.device_id)
         max_rsrv_mem_byte = torch.cuda.max_memory_reserved(self.device_id)
         self.csv_writer.writerow([
@@ -108,27 +121,26 @@ def main():
     parser.add_argument('filename', type=str,
                         help="Specifies the path to the model JSON file")
     parser.add_argument('deviceid', type=int, help="Specifies the gpu to run")
+    parser.add_argument('--sync-model-load', action="store_true",
+                        help="Load model and wait until run message is "
+                        "received to start execution. Default: do not wait.")
     args = parser.parse_args()
     filename = args.filename
     device_id = args.deviceid
 
-    print("Device", device_id)
+    debug_print(f"proc {os.getpid()}, set Device {device_id}")
     # set the directory for downloading models
     torch.hub.set_dir("../torch_cache/")
     # set the cuda device to use
     torch.cuda.set_device(device_id)
     try:
-        print(f"run_model.py: parsing file: {filename}")
         data = read_json_file(filename)
-        print(f"Model: {data['model_name']}")
-        print("Fields:")
-        print(json.dumps(data, indent=4))
     except (FileNotFoundError, json.JSONDecodeError, KeyError):
-        print(f"Invalid input file.", file=sys.stderr)
+        debug_print(f"Invalid input file.")
         sys.exit(1)
 
     tester: SchedulerTester = SchedulerTester(
-        data['control']['control'], data, device_id)
+        data['control']['control'], data, device_id, args.sync_model_load)
     sleep(1)
     tester.run()
 

--- a/gpu-sched-exp/gpu-tester/src/utils.py
+++ b/gpu-sched-exp/gpu-tester/src/utils.py
@@ -1,7 +1,8 @@
 import collections
 import json
-import time
 import re
+import sys
+import time
 import numpy as np
 import yaml
 import pandas as pd
@@ -49,15 +50,16 @@ def get_jcts_from_profile(profile_filename):
 
 
 class print_time:
-    def __init__(self, desc):
+    def __init__(self, desc, file=sys.stdout):
         self.desc = desc
+        self.file = file
 
     def __enter__(self):
         print(self.desc)
         self.t = time.time()
 
     def __exit__(self, type, value, traceback):
-        print(f'{self.desc} took {time.time()-self.t:.02f}s')
+        print(f'{self.desc} took {time.time()-self.t:.02f}s', file=self.file)
 
 def get_config_name(config):
     if "resize_size" in config:

--- a/gpu-sched-exp/gpu-tester/src/vision_model.py
+++ b/gpu-sched-exp/gpu-tester/src/vision_model.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import cv2
 import numpy as np
 import torch
@@ -44,7 +45,7 @@ class VisionModel:
         else:
             raise ValueError("Unrecognized model weight and model name in "
                              "torchvision.")
-        with print_time('loading parameters'):
+        with print_time('loading parameters', sys.stderr):
             self.model: torch.nn.Module = model_cls(weights=self.weights).eval().cuda()
         self.resize_size = tuple(config['resize_size'])
         self.model_preprocess = self.weights.transforms()

--- a/gpu-sched-exp/intercept-lib/src/hooks.cc
+++ b/gpu-sched-exp/intercept-lib/src/hooks.cc
@@ -85,7 +85,7 @@ int get_start_time() {
     struct timespec timespc;
     clock_gettime(CLOCK_REALTIME, &timespc);
     float cur = (timespc.tv_sec * 1000000000 + timespc.tv_nsec) / 1000 % 100000000 / 1000.0;
-    printf("Starting at %f, id =  %d\n", cur, get_id());
+    // printf("Starting at %f, id =  %d\n", cur, get_id());
     return 1;
 }
 


### PR DESCRIPTION
Problem: when model A process already finishes model loading and starts to run, it takes most of GPU SMs/cycles. This may cause model B loading extremely slow. 

Solution: use message exchange to synchronize all processes until they finish their own model loading. Then they start to run the DNN inference.